### PR TITLE
Open up CORS config to * so firebase previews work

### DIFF
--- a/cors.json
+++ b/cors.json
@@ -1,10 +1,7 @@
 [
   {
     "origin": [
-      "http://lvh.me:3000",
-      "http://localhost:3000",
-      "https://nzwirelessmap-firebase.firebaseapp.com",
-      "https://wirelessmap.markhansen.co.nz"
+      "*"
     ],
     "responseHeader": [
       "Content-Type"


### PR DESCRIPTION
CORS doesn't have a way to apply to wildcard parts of a domain, so I can't match all the firebase preview URLs I'll get like https://nzwirelessmap-firebase--pr75-renovate-npm-10-x-lo-g68x4glq.web.app/

See https://stackoverflow.com/questions/14003332/access-control-allow-origin-wildcard-subdomains-ports-and-protocols

I don't think there's a good reason to keep it restricted; I don't care if someone uses this on another website, except for the egress fees, I suppose, which they can already grief me with by forging headers.